### PR TITLE
Cleanup the contents of /tmp in warden rootfs

### DIFF
--- a/lucid64/build
+++ b/lucid64/build
@@ -126,6 +126,9 @@ run_in_chroot $rootfs_dir "
   /usr/local/bin/ruby-build 1.9.3-p392 /usr
 "
 
+# cleanup artifacts in /tmp
+rm -rf $rootfs_dir/tmp/*
+
 # package up rootfs
 cd $rootfs_dir
 tar czf /vagrant/rootfs.tgz *


### PR DESCRIPTION
No reason to carry a bunch of build logs and temporary files into the
root file system so remove the contents before archiving.

Signed-off-by: Michael Fraenkel fraenkel@us.ibm.com
