### PR TITLE
Downgrade to libreadline-dev version 5

### DIFF
--- a/lucid64/build
+++ b/lucid64/build
@@ -34,7 +34,7 @@ packages="
   libmysqlclient-dev
   libncurses5-dev
   libpq-dev
-  libreadline6-dev
+  libreadline5-dev
   libsqlite-dev
   libsqlite3-dev
   libssl-dev


### PR DESCRIPTION
The CF PHP buildpack we're currently building requires libreadline.so.5,
which is part of the libreadline-dev C++ library, version 5.  Prior to
this commit, the rootfs performs an apt-get of libreadline-dev version
6.
