### PR TITLE
Include libreadline5 and libreadline5-dev

### DIFF
--- a/lucid64/build
+++ b/lucid64/build
@@ -34,7 +34,9 @@ packages="
   libmysqlclient-dev
   libncurses5-dev
   libpq-dev
-  libreadline6-dev
+  libreadline5
+  libreadline5-dev
+  libreadline6
   libsqlite-dev
   libsqlite3-dev
   libssl-dev


### PR DESCRIPTION
The CF PHP buildpack we're currently building requires libreadline.so.5,
which is part of the libreadline-dev C++ library, version 5.

Prior to this commit, the rootfs only performed an apt-get of
libreadline6-dev.  These packages are not compatible side-by-side, so
libreadline6-dev has been replaced with libreadline6.
