### PR TITLE
Create core dump directory

### DIFF
--- a/lucid64/build
+++ b/lucid64/build
@@ -91,6 +91,10 @@ dpkg-reconfigure -fnoninteractive -pcritical libc6
 dpkg-reconfigure -fnoninteractive -pcritical locales
 "
 
+# core dump directory
+mkdir -p $rootfs_dir/var/vcap/sys/cores
+chmod ugo+rwx $rootfs_dir/var/vcap/sys/cores
+
 # firstboot script
 cp $assets_dir/etc/rc.local $rootfs_dir/etc/rc.local
 cp $assets_dir/root/firstboot.sh $rootfs_dir/root/firstboot.sh


### PR DESCRIPTION
The core dump directory is set via /proc/sys/kernel/core_pattern and can't be
overridden in the container so it inherits its value from the dea. This
is fine except the dea sets the directory to /var/vcap/sys/cores which
does not exist inside the container. This means that core dumps (which
some buildpacks want to be able to access) cannot be accessed inside the
container. 

This change adds a matching /var/vcap/sys/cores directory
inside the container so that core dumps work. Note that this still
prevents core dumps by default because the standard warden configuration sets the
max core dump size to 0, but this can (already) be separately overridden in [warden's linux.yml's container_rlimits section](https://github.com/cloudfoundry/warden/blob/master/warden/config/linux.yml#L29).

/cc @fraenkel 
