### PR TITLE
Add libssl0.9.8

### DIFF
--- a/trusty64/build/install-packages.sh
+++ b/trusty64/build/install-packages.sh
@@ -130,6 +130,7 @@ traceroute
 unzip
 wget
 zip
+libssl0.9.8
 "
 
 ## Pulled from Diego Trusty rootfs


### PR DESCRIPTION
Fixed ruby-buildpack problem

before fail

``` bash
$ cf logs dora
Connected, tailing logs for app dora in org develop / space develop-space as admin...

2015-02-10T19:40:50.18+0900 [API]     OUT Updated app with guid 5e43857a-f16e-466d-8c7c-c4675c622276 ({"name"=>"dora", "instances"=>1})
2015-02-10T19:40:55.64+0900 [API]     OUT Updated app with guid 5e43857a-f16e-466d-8c7c-c4675c622276 ({"state"=>"STOPPED"})
2015-02-10T19:40:56.17+0900 [DEA]     OUT Got staging request for app with id 5e43857a-f16e-466d-8c7c-c4675c622276
2015-02-10T19:40:57.35+0900 [API]     OUT Updated app with guid 5e43857a-f16e-466d-8c7c-c4675c622276 ({"state"=>"STARTED"})
2015-02-10T19:40:57.51+0900 [STG]     OUT -----> Downloaded app package (1.2M)
2015-02-10T19:40:57.89+0900 [STG]     OUT -------> Buildpack version 1.1.4
2015-02-10T19:40:58.14+0900 [STG]     OUT -----> Compiling Ruby/Rack
2015-02-10T19:40:58.82+0900 [STG]     OUT -----> Using Ruby version: ruby-2.0.0
2015-02-10T19:40:58.90+0900 [STG]     OUT -----> Installing dependencies using 1.6.3
2015-02-10T19:40:59.09+0900 [STG]     OUT        Running: bundle install --without development:test --path vendor/bundle --binstubs vendor/bundle/bin -j4 --deployment
2015-02-10T19:40:59.25+0900 [STG]     OUT        Could not load OpenSSL.
2015-02-10T19:40:59.27+0900 [STG]     OUT        You must recompile Ruby with OpenSSL support or change the sources in your
2015-02-10T19:40:59.27+0900 [STG]     OUT        Gemfile from 'https' to 'http'. Instructions for compiling with OpenSSL using
2015-02-10T19:40:59.27+0900 [STG]     OUT        RVM are available at http://rvm.io/packages/openssl.
2015-02-10T19:40:59.28+0900 [STG]     OUT        Bundler Output:
2015-02-10T19:40:59.28+0900 [STG]     OUT        Could not load OpenSSL.
2015-02-10T19:40:59.28+0900 [STG]     OUT        You must recompile Ruby with OpenSSL support or change the sources in your
2015-02-10T19:40:59.28+0900 [STG]     OUT        Gemfile from 'https' to 'http'. Instructions for compiling with OpenSSL using
2015-02-10T19:40:59.28+0900 [STG]     OUT        RVM are available at http://rvm.io/packages/openssl.
2015-02-10T19:40:59.29+0900 [STG]     OUT  !
2015-02-10T19:40:59.29+0900 [STG]     OUT  !     Failed to install gems via Bundler.
2015-02-10T19:40:59.29+0900 [STG]     OUT  !
2015-02-10T19:40:59.30+0900 [STG]     OUT Staging failed: Buildpack compilation step failed
2015-02-10T19:40:59.31+0900 [STG]     ERR 
2015-02-10T19:40:59.49+0900 [API]     ERR Encountered error: App staging failed in the buildpack compile phase
```

after (add libssl0.9.8)

``` bash
$ cf push dora 
Creating app dora in org develop / space develop-space as admin...
OK

Using route dora.10.244.0.34.xip.io
Binding dora.10.244.0.34.xip.io to dora...
OK

Uploading dora...
Uploading app files from: /home/ntt/cf-release/src/acceptance-tests/assets/dora
Uploading 182.5K, 38 files
Done uploading               
OK

Starting app dora in org develop / space develop-space as admin...
-----> Downloaded app package (1.2M)
-------> Buildpack version 1.1.4
-----> Compiling Ruby/Rack
-----> Using Ruby version: ruby-2.0.0
-----> Installing dependencies using 1.6.3
       Running: bundle install --without development:test --path vendor/bundle --binstubs vendor/bundle/bin -j4 --deployment
       Installing tilt 1.3.3
       Using bundler 1.6.3
       Installing rack 1.5.1
       Installing rack-protection 1.3.2
       Installing sinatra 1.3.4
       Installing json 1.8.1
       Your bundle is complete!
       Gems in the groups development and test were not installed.
       It was installed into ./vendor/bundle
       Bundle completed (2.30s)
       Cleaning up the bundler cache.
###### WARNING:
       No Procfile detected, using the default web server (webrick)
       https://devcenter.heroku.com/articles/ruby-default-web-server

-----> Uploading droplet (14M)

1 of 1 instances running

App started


OK
Showing health and status for app dora in org develop / space develop-space as admin...
OK

requested state: started
instances: ?/1
usage: 256M x 1 instances
urls: dora.10.244.0.34.xip.io
last uploaded: Thu Feb 12 01:40:48 +0000 2015

     state     since                    cpu    memory          disk   
#0   running   2015-02-12 10:41:07 AM   0.0%   35.4M of 256M   0 of 1G

$ curl dora.10.244.0.34.xip.io
Hi, I'm Dora!
```
