### PR TITLE
Bump Ruby to 1.9.3 p551

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@
 *.tgz
 *.tar.gz
 cflinuxfs2/cflinuxfs2_dpkg_l.out
+lucid64/lucid64_dpkg_l.out 
 rootfs_lucid_dpkg_l.out
 .idea

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ This will remove the `cflinuxfs2/rootfs.tgz` file, but the tarball `cflinuxfs2.t
 
 # Updating rootfs blob in cf-release
 
-To update rootfs package in cf-release overwrite rootfs blob cf-release/blobs/rootfs/[ROOTFS_NAME].tar.gz with the new tarball.
+Run `bosh add [ROOTFS_NAME].tar.gz blob rootfs ` to update rootfs package in cf-release.
 
 Run `bosh upload blobs` to upload package to bosh blobstore.
 

--- a/cflinuxfs2/Dockerfile
+++ b/cflinuxfs2/Dockerfile
@@ -5,7 +5,7 @@ ADD assets /tmp/assets
 
 RUN bash /tmp/build/configure-locale-timezone.sh
 RUN bash /tmp/build/install-packages.sh
-RUN bash /tmp/build/install-ruby.sh 1.9.3-p547
+RUN bash /tmp/build/install-ruby.sh 1.9.3-p551
 RUN bash /tmp/build/configure-core-dump-directory.sh
 RUN bash /tmp/build/configure-firstboot.sh
 RUN bash /tmp/build/diego-prep.sh

--- a/lucid64/Dockerfile
+++ b/lucid64/Dockerfile
@@ -7,7 +7,7 @@ ADD assets /tmp/assets
 
 RUN bash /tmp/build/configure-locale-timezone.sh
 RUN bash /tmp/build/install-packages.sh
-RUN bash /tmp/build/install-ruby.sh 1.9.3-p547
+RUN bash /tmp/build/install-ruby.sh 1.9.3-p551
 RUN bash /tmp/build/configure-core-dump-directory.sh
 RUN bash /tmp/build/configure-firstboot.sh
 RUN bash -c '\


### PR DESCRIPTION
Update Ruby to 1.9.3 p551
Fix readme and gitignore.

Ruby changelog : 

```
Thu Nov 13 22:36:17 2014  CHIKANAGA Tomoyuki  <nagachika@ruby-lang.org>

    * lib/rexml/document.rb: add REXML::Document#document.
      reported by Tomas Hoger <thoger@redhat.com> and patched by nahi.

Mon Oct 27 20:23:27 2014  NAKAMURA Usaku  <usa@ruby-lang.org>

    * lib/rexml/entity.rb: keep the entity size within the limitation.
      reported by Willis Vandevanter <will@silentrobots.com> and
      patched by nahi.

Thu Oct 24 12:00:55 2014  CHIKANAGA Tomoyuki  <nagachika@ruby-lang.org>

    * ext/openssl/lib/openssl/ssl-internal.rb (DEFAULT_PARAMS): override
      options even if OpenSSL::SSL::OP_NO_SSLv3 is not defined.
      this is pointed out by Stephen Touset. [ruby-core:65711] [Bug #9424]

Thu Oct 24 12:00:55 2014  Martin Bosslet  <Martin.Bosslet@gmail.com>

    * test/openssl/test_ssl.rb: Reuse TLS default options from
      OpenSSL::SSL::SSLContext::DEFAULT_PARAMS.

Thu Oct 24 12:00:55 2014  Martin Bosslet  <Martin.Bosslet@gmail.com>

    * lib/openssl/ssl-internal.rb: Explicitly whitelist the default
      SSL/TLS ciphers. Forbid SSLv2 and SSLv3, disable
      compression by default.
      Reported by Jeff Hodges.
      [ruby-core:59829] [Bug #9424]

Sat Sep  6 09:13:55 2014  Zachary Scott  <e@zzak.io>

    * lib/rdoc/generator/template/darkfish/js/jquery.js: Backport
      rdoc/rdoc@74f60fcb04fee1778fe2694d1a0ea6513f8e67b7
```
