### PR TITLE
Dockerfile creates /app in cflinuxfs2 image

### DIFF
--- a/cflinuxfs2/Dockerfile
+++ b/cflinuxfs2/Dockerfile
@@ -10,4 +10,7 @@ RUN bash /tmp/build/configure-core-dump-directory.sh
 RUN bash /tmp/build/configure-firstboot.sh
 RUN bash /tmp/build/diego-prep.sh
 
+# /app must exist so we can bind-mount it to /home/vcap in seed
+RUN mkdir /app
+
 RUN rm -rf /tmp/*


### PR DESCRIPTION
- The /etc/seed script assumes this directory is present, but root
  inside a non-privileged garden container cannot create the directory itself

[#90425196]

Signed-off-by: Matt Royal mroyal@pivotal.io
