### PR TITLE
Add `cmake` to rootfses

### DIFF
--- a/cflinuxfs2/build/install-packages.sh
+++ b/cflinuxfs2/build/install-packages.sh
@@ -14,6 +14,7 @@ bind9-host
 bison
 build-essential
 ca-certificates
+cmake
 cron
 curl
 dmidecode

--- a/lucid64/build/install-packages.sh
+++ b/lucid64/build/install-packages.sh
@@ -84,6 +84,7 @@ bind9-host
 bison
 build-essential
 ca-certificates
+cmake
 curl
 dnsutils
 flex


### PR DESCRIPTION
`cmake` is a build tool, similar in purpose to `make`, that is used by
some libraries.

See https://www.pivotaltracker.com/story/show/93807472 for one example
of a ruby gem, "rugged", that requires `cmake` to be installed.
