### PR TITLE
Add autoconf to rootfs

### DIFF
--- a/cflinuxfs2/build/install-packages.sh
+++ b/cflinuxfs2/build/install-packages.sh
@@ -10,6 +10,7 @@ function apt_get() {
 
 packages="
 aptitude
+autoconf
 bind9-host
 bison
 build-essential

--- a/lucid64/build/install-packages.sh
+++ b/lucid64/build/install-packages.sh
@@ -8,6 +8,7 @@ function apt_get() {
 
 packages_from_debootstrap="
 aptitude
+autoconf
 cron
 dmidecode
 dmsetup


### PR DESCRIPTION
Required to build Ruby, among other packages. Used to generate `configure` file.
