### PR TITLE
Add libpcre3-dev

### DIFF
--- a/cflinuxfs2/build/install-packages.sh
+++ b/cflinuxfs2/build/install-packages.sh
@@ -76,6 +76,7 @@ libopenexr-dev
 libopenexr6
 libpango1.0-0
 libparse-debianchangelog-perl
+libpcre3-dev
 libpixman-1-0
 libpq-dev
 libreadline6-dev


### PR DESCRIPTION
partially to encourage people to stop statically linking against
libpcre3, related to CVE-2015-3210
