### PR TITLE
fix(libraries): Adding Fortran compiler

### DIFF
--- a/cflinuxfs2/build/install-packages.sh
+++ b/cflinuxfs2/build/install-packages.sh
@@ -23,6 +23,7 @@ flex
 fontconfig
 fuse-emulator-utils
 gdb
+gfortran
 git-core
 gnupg-curl
 gsfonts


### PR DESCRIPTION
SciPy requires a Fortran compiler for building. Adding
gfortran to the list of libraries for the cflinuxfs2 stack.

closes #23 

Signed-off-by: John Bufe john.bufe@us.ibm.com
