### PR TITLE
fix(libraries): Adding Atlas package

### DIFF
--- a/cflinuxfs2/build/install-packages.sh
+++ b/cflinuxfs2/build/install-packages.sh
@@ -34,6 +34,7 @@ laptop-detect
 less
 libaio1
 libatk1.0-0
+libatlas-base-dev
 libatm1
 libavahi-client3
 libavahi-common-data


### PR DESCRIPTION
Adding the Atlas package to the installation for cflinuxfs2 to support NumPy methods.

Closes #24 

Signed-off-by: John Bufe john.bufe@us.ibm.com
