### PR TITLE
Enable ppc64le support

### DIFF
--- a/cflinuxfs2/Dockerfile.ppc64le
+++ b/cflinuxfs2/Dockerfile.ppc64le
@@ -6,7 +6,7 @@ ADD assets /tmp/assets
 RUN bash /tmp/build/configure-locale-timezone.sh
 RUN bash /tmp/build/install-packages.sh
 RUN bash /tmp/build/generate-all-locales.sh
-RUN bash /tmp/build/install-ruby.sh 2.2.1
+RUN bash /tmp/build/install-ruby.sh 1.9.3-p547
 RUN bash /tmp/build/configure-core-dump-directory.sh
 RUN bash /tmp/build/configure-firstboot.sh
 

--- a/cflinuxfs2/Dockerfile.ppc64le
+++ b/cflinuxfs2/Dockerfile.ppc64le
@@ -1,0 +1,19 @@
+FROM ppc64le/ubuntu:trusty
+
+ADD build /tmp/build
+ADD assets /tmp/assets
+
+RUN bash /tmp/build/configure-locale-timezone.sh
+RUN bash /tmp/build/install-packages.sh
+RUN bash /tmp/build/generate-all-locales.sh
+RUN bash /tmp/build/install-ruby.sh 2.2.1
+RUN bash /tmp/build/configure-core-dump-directory.sh
+RUN bash /tmp/build/configure-firstboot.sh
+
+# create the vcap for garden and warden
+RUN useradd -mU -s /bin/bash vcap
+RUN mkdir /home/vcap/app
+RUN chown vcap /home/vcap/app
+RUN ln -s /home/vcap/app /app
+
+RUN rm -rf /tmp/*

--- a/cflinuxfs2/build/install-packages.sh
+++ b/cflinuxfs2/build/install-packages.sh
@@ -135,11 +135,17 @@ unzip
 wget
 zip
 "
+if [ "`uname -m`" == "ppc64le" ]; then
+packages=$(sed '/\b\(libopenblas-dev\|libdrm-intel1\|dmidecode\)\b/d' <<< "${packages}")
+ubuntu_url="http://ports.ubuntu.com/ubuntu-ports"
+else
+ubuntu_url="http://archive.ubuntu.com/ubuntu"
+fi
 
 cat > /etc/apt/sources.list <<EOS
-deb http://archive.ubuntu.com/ubuntu $DISTRIB_CODENAME main universe multiverse
-deb http://archive.ubuntu.com/ubuntu $DISTRIB_CODENAME-updates main universe multiverse
-deb http://security.ubuntu.com/ubuntu $DISTRIB_CODENAME-security main universe multiverse
+deb $ubuntu_url $DISTRIB_CODENAME main universe multiverse
+deb $ubuntu_url $DISTRIB_CODENAME-updates main universe multiverse
+deb $ubuntu_url $DISTRIB_CODENAME-security main universe multiverse
 EOS
 
 # install gpgv so we can update

--- a/cflinuxfs2/build/install-ruby.sh
+++ b/cflinuxfs2/build/install-ruby.sh
@@ -6,11 +6,17 @@ if [ -z "$RUBY_VERSION" ]; then
     echo "usage: ${0} [VERSION]."
     exit 1
 fi
+if [ "`uname -m`" == "ppc64le" ]; then
+    OPTS="--build=powerpc64le-linux-gnu"
+else
+    OPTS=""
+fi
 
 git clone git://github.com/sstephenson/ruby-build.git /tmp/ruby-build
 pushd /tmp/ruby-build
   PREFIX=/usr/local ./install.sh
   RUBY_CONFIGURE_OPTS=--disable-install-doc \
+  CONFIGURE_OPTS=$OPTS \
     /usr/local/bin/ruby-build $RUBY_VERSION /usr
 popd
 rm -rf /tmp/ruby-build*


### PR DESCRIPTION
This patch adds support for building stack on POWER Linux:
- add new Dockerfile for ppc64le arch and change Makefile accordingly
- add another source repositories in sources.list in case of ppc64le
- remove unsupported packages for ppc64le
