### PR TITLE
Revert "Add python-dev"

### DIFF
--- a/cflinuxfs2/build/install-packages.sh
+++ b/cflinuxfs2/build/install-packages.sh
@@ -132,7 +132,6 @@ openssh-server
 openssl
 psmisc
 python
-python-dev
 quota
 rsync
 shared-mime-info


### PR DESCRIPTION
Reverts cloudfoundry/stacks#34

Reverted as further review revealed no compelling downstream dependencies for `python-dev`.
