### PR TITLE
Add golang support for ppc64le

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 all: cflinuxfs2.tar.gz
 
+ifndef GO_URL
+  GO_URL="https://buildpacks.cloudfoundry.org/concourse-binaries/go/go1.7.3.linux-amd64.tar.gz"
+endif
+
 arch:=$(shell uname -m)
 ifeq ("$(arch)","ppc64le")
         docker_image := "ppc64le/ubuntu:trusty"
@@ -12,7 +16,7 @@ else
 endif
 
 cflinuxfs2.cid: 
-	docker build --no-cache -f $(docker_file) -t cloudfoundry/cflinuxfs2 cflinuxfs2
+	docker build --no-cache -f $(docker_file) -t cloudfoundry/cflinuxfs2 --build-arg go_url=$(GO_URL) cflinuxfs2
 	docker run --cidfile=cflinuxfs2.cid cloudfoundry/cflinuxfs2 dpkg -l | tee cflinuxfs2/cflinuxfs2_dpkg_l.out
 
 cflinuxfs2.tar: cflinuxfs2.cid

--- a/cflinuxfs2/Dockerfile
+++ b/cflinuxfs2/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:trusty
 
+ARG go_url
+
 ADD build /tmp/build
 ADD assets /tmp/assets
 
@@ -9,7 +11,7 @@ RUN bash /tmp/build/generate-all-locales.sh
 RUN bash /tmp/build/install-ruby.sh 2.3.1
 RUN bash /tmp/build/configure-core-dump-directory.sh
 RUN bash /tmp/build/configure-firstboot.sh
-RUN bash /tmp/build/install-go.sh 1.7.3
+RUN bash /tmp/build/install-go.sh $go_url
 
 # create the vcap for garden and warden
 RUN useradd -u 2000 -mU -s /bin/bash vcap

--- a/cflinuxfs2/build/install-go.sh
+++ b/cflinuxfs2/build/install-go.sh
@@ -7,18 +7,20 @@ if [ -z "$GO_VERSION" ]; then
     exit 1
 fi
 
-if [ "`uname -m`" == "ppc64le" ]; then
-  echo "Go $GO_VERSION is not available for download for ppc64le"
-else
-  pushd /tmp
+pushd /tmp
+  if [ "`uname -m`" == "ppc64le" ]; then
+    GO_TAR_FILE="go-$GO_VERSION-ppc64le.tar.gz"
+    wget "http://ftp.unicamp.br/pub/ppc64el/ubuntu/14_04/cloud-foundry/$GO_TAR_FILE"
+  else
     GO_TAR_FILE="go$GO_VERSION.linux-amd64.tar.gz"
     wget "https://buildpacks.cloudfoundry.org/concourse-binaries/go/$GO_TAR_FILE"
-    tar -xvf $GO_TAR_FILE
-    mv go /usr/local/go1.7
-  popd
+  fi
+  tar -xvf $GO_TAR_FILE
+  mv go /usr/local/go1.7
+popd
 
-  rm "/tmp/$GO_TAR_FILE"
-fi
+rm "/tmp/$GO_TAR_FILE"
+
 
 
 

--- a/cflinuxfs2/build/install-go.sh
+++ b/cflinuxfs2/build/install-go.sh
@@ -1,25 +1,19 @@
 set -e -x
 
-GO_VERSION=${1}
+GO_URL=${1}
 
-if [ -z "$GO_VERSION" ]; then
-    echo "usage: ${0} [VERSION]."
+if [ -z "$GO_URL" ]; then
+    echo "usage: ${0} [URL]."
     exit 1
 fi
 
 pushd /tmp
-  if [ "`uname -m`" == "ppc64le" ]; then
-    GO_TAR_FILE="go-$GO_VERSION-ppc64le.tar.gz"
-    wget "http://ftp.unicamp.br/pub/ppc64el/ubuntu/14_04/cloud-foundry/$GO_TAR_FILE"
-  else
-    GO_TAR_FILE="go$GO_VERSION.linux-amd64.tar.gz"
-    wget "https://buildpacks.cloudfoundry.org/concourse-binaries/go/$GO_TAR_FILE"
-  fi
-  tar -xvf $GO_TAR_FILE
+  wget $GO_URL
+  tar -xvf ${GO_URL##*/}
   mv go /usr/local/go1.7
 popd
 
-rm "/tmp/$GO_TAR_FILE"
+rm "/tmp/${GO_URL##*/}"
 
 
 


### PR DESCRIPTION
There is a stub only for ppc64le version of the golang 1.7.3 at this moment. `ftp.unicamp.br/pub/ppc64el/ubuntu/14_04/cloud-foundry` is a repo for publishing ppc64le specific golang versions.