### PR TITLE
Enable armhf support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,20 @@
 all: cflinuxfs2.tar.gz
 
+docker_image := "ubuntu:trusty"
+docker_file := cflinuxfs2/Dockerfile
+
 arch:=$(shell uname -m)
 ifeq ("$(arch)","ppc64le")
         docker_image := "ppc64le/ubuntu:trusty"
         docker_file := cflinuxfs2/Dockerfile.$(arch)
         $(shell cp cflinuxfs2/Dockerfile $(docker_file))
         $(shell sed -i 's/FROM ubuntu:trusty/FROM ppc64le\/ubuntu:trusty/g' $(docker_file))
-else
-        docker_image := "ubuntu:trusty"
-        docker_file := cflinuxfs2/Dockerfile
+endif
+ifeq ("$(arch)","armv7l")
+        docker_image := "armv7/armhf-ubuntu_core:14.04"
+        docker_file := cflinuxfs2/Dockerfile.$(arch)
+        $(shell cp cflinuxfs2/Dockerfile $(docker_file))
+        $(shell sed -i 's/FROM ubuntu:trusty/FROM armv7\/armhf-ubuntu_core:14.04/g' $(docker_file))
 endif
 
 cflinuxfs2.cid: 

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,24 @@
 all: cflinuxfs2.tar.gz
 
+docker_image := "ubuntu:trusty"
+docker_file := cflinuxfs2/Dockerfile
+
 arch:=$(shell uname -m)
 ifeq ("$(arch)","ppc64le")
         docker_image := "ppc64le/ubuntu:trusty"
         docker_file := cflinuxfs2/Dockerfile.$(arch)
         $(shell cp cflinuxfs2/Dockerfile $(docker_file))
         $(shell sed -i 's/FROM ubuntu:trusty/FROM ppc64le\/ubuntu:trusty/g' $(docker_file))
-else
-        docker_image := "ubuntu:trusty"
-        docker_file := cflinuxfs2/Dockerfile
+endif
+ifeq ("$(arch)","armv7l")
+        docker_image := "armv7/armhf-ubuntu_core:14.04"
+        docker_file := cflinuxfs2/Dockerfile.$(arch)
+        $(shell cp cflinuxfs2/Dockerfile $(docker_file))
+        $(shell sed -i 's/FROM ubuntu:trusty/FROM armv7\/armhf-ubuntu_core:14.04/g' $(docker_file))
 endif
 
 cflinuxfs2.cid: 
-	docker build --no-cache -f $(docker_file) -t cloudfoundry/cflinuxfs2 cflinuxfs2
+	docker build  -f $(docker_file) -t cloudfoundry/cflinuxfs2 cflinuxfs2
 	docker run --cidfile=cflinuxfs2.cid cloudfoundry/cflinuxfs2 dpkg -l | tee cflinuxfs2/cflinuxfs2_dpkg_l.out
 
 cflinuxfs2.tar: cflinuxfs2.cid

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ ifeq ("$(arch)","armv7l")
 endif
 
 cflinuxfs2.cid: 
-	docker build  -f $(docker_file) -t cloudfoundry/cflinuxfs2 cflinuxfs2
+	docker build --no-cache -f $(docker_file) -t cloudfoundry/cflinuxfs2 cflinuxfs2
 	docker run --cidfile=cflinuxfs2.cid cloudfoundry/cflinuxfs2 dpkg -l | tee cflinuxfs2/cflinuxfs2_dpkg_l.out
 
 cflinuxfs2.tar: cflinuxfs2.cid

--- a/cflinuxfs2/Dockerfile
+++ b/cflinuxfs2/Dockerfile
@@ -1,4 +1,4 @@
-FROM armv7/armhf-ubuntu_core:14.04
+FROM ubuntu:trusty
 
 ADD build /tmp/build
 ADD assets /tmp/assets

--- a/cflinuxfs2/Dockerfile
+++ b/cflinuxfs2/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:trusty
+FROM armv7/armhf-ubuntu_core:14.04
 
 ADD build /tmp/build
 ADD assets /tmp/assets

--- a/cflinuxfs2/build/install-packages.sh
+++ b/cflinuxfs2/build/install-packages.sh
@@ -11,12 +11,20 @@ function install_mysql_so_files() {
     if [ "`uname -m`" == "ppc64le" ]; then
         mysqlpath="/usr/lib/powerpc64le-linux-gnu"
     fi
+    if [ "`uname -m`" == "armv7l" ]; then
+        mysqlpath="/usr/lib/arm-linux-gnueabihf"
+    fi
     apt_get install libmysqlclient-dev
     tmp=`mktemp -d`
     mv $mysqlpath/libmysqlclient* $tmp
     apt_get remove libmysqlclient-dev libmysqlclient18
     mv $tmp/* $mysqlpath/
 }
+
+arch="amd64"
+if [ "`uname -m`" == "armv7l" ]; then
+    arch="armhf"
+fi
 
 packages="
 aptitude
@@ -44,14 +52,14 @@ laptop-detect
 libaio1
 libatm1
 libavcodec54
-libboost-iostreams1.54.0:amd64
+libboost-iostreams1.54.0:"$arch"
 libcurl4-openssl-dev
 libcwidget3
 libdirectfb-1.2-9
 libdrm-intel1
 libdrm-nouveau2
 libdrm-radeon1
-libept1.4.12:amd64
+libept1.4.12:"$arch"
 libfuse-dev
 libgd2-noxpm-dev
 libgmp-dev
@@ -70,7 +78,7 @@ libreadline6-dev
 libsasl2-dev
 libsasl2-modules
 libselinux1-dev
-libsigc++-2.0-0c2a:amd64
+libsigc++-2.0-0c2a:"$arch"
 libsqlite0-dev
 libsqlite3-dev
 libsysfs2
@@ -101,7 +109,8 @@ uuid-dev
 wget
 zip
 "
-if [ "`uname -m`" == "ppc64le" ]; then
+
+if [ "`uname -m`" == "ppc64le" ] || [ "`uname -m`" == "armv7l" ]; then
 packages=$(sed '/\b\(libopenblas-dev\|libdrm-intel1\|dmidecode\)\b/d' <<< "${packages}")
 ubuntu_url="http://ports.ubuntu.com/ubuntu-ports"
 else

--- a/cflinuxfs2/build/install-ruby.sh
+++ b/cflinuxfs2/build/install-ruby.sh
@@ -6,10 +6,12 @@ if [ -z "$RUBY_VERSION" ]; then
     echo "usage: ${0} [VERSION]."
     exit 1
 fi
+OPTS=""
 if [ "`uname -m`" == "ppc64le" ]; then
     OPTS="--build=powerpc64le-linux-gnu"
-else
-    OPTS=""
+fi
+if [ "`uname -m`" == "armv7l" ]; then
+    OPTS="--build=arm-linux-gnueabihf"
 fi
 
 git clone git://github.com/sstephenson/ruby-build.git /tmp/ruby-build


### PR DESCRIPTION
This PR provides support for building stack on arm linux:

- replace base image in case of armv7l to ubuntu core
- in case of armv7l use the ubuntu ports repos (same as ppc64le)
- replace several hardcoded amd64 packages with architecture dependent versions