### PR TITLE
Add gssapi module for libsasl2 to allow for Kerberos authentication via SASL

### DIFF
--- a/cflinuxfs2/build/install-packages.sh
+++ b/cflinuxfs2/build/install-packages.sh
@@ -77,6 +77,7 @@ libpq-dev
 libreadline6-dev
 libsasl2-dev
 libsasl2-modules
+libsasl2-modules-gssapi-mit
 libselinux1-dev
 libsigc++-2.0-0c2a:"$arch"
 libsqlite0-dev


### PR DESCRIPTION
`libsasl2` and `libsasl2-modules` are already included by default. Including `libsasl2-modules-gssapi-mit` as well would allow applications that rely upon SASL to perform authentication to also use Kerberos-type authentication without any additional installation.